### PR TITLE
Added a positioning test case with width and margin

### DIFF
--- a/inspector/positions.html
+++ b/inspector/positions.html
@@ -9,6 +9,7 @@
 .absolute-bottom-right { position: absolute; bottom: 20px; right: 50px; background: #fcc; }
 .absolute-all-4 { position: absolute; top: 100px; bottom: 10px; left: 20px; right: 700px; background: #fcc; }
 .absolute-negative { position: absolute; bottom: -25px; background: #fcc; }
+.absolute-width-margin { position: absolute; top: 20px; right: 20px; width: 150px; margin: 1em; padding: 10px; border: 2px solid red; box-sizing: border-box; background: #fcc; }
 
 .relative { position: relative; top: 10px; left: 10px; background: #cfc;}
 
@@ -72,6 +73,9 @@
   </div>
   <div class="absolute-negative">
     Absolute child with a relative parent, with negative positions
+  </div>
+  <div class="absolute-width-margin">
+    Absolute child with a relative parent, with a size and a margin
   </div>
 </div>
 


### PR DESCRIPTION
The new geometry highlighter shows both the position and size, but since these 2 things aren't calculated against the same box (margin-box for the position and content-box for the size, or whatever box-sizing is set to), I needed a new test case for this.