### PR TITLE
Added a jquery animations page (that mutates style attributes) to test the markup-view perf

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
   <li><a href="inspector/form.html">Form Controls</a></li>
   <li><a href="inspector/inherited.html">Inherited Styles</a></li>
   <li><a href="inspector/authored-styles.html">Authored Styles</a></li>
+  <li><a href="inspector/jquery-animation.html">Many jQuery animations for testing the markup-view refresh performance</a></li>
 </ul>
 
 <h2>Style Editor</h2>

--- a/inspector/jquery-animation.html
+++ b/inspector/jquery-animation.html
@@ -1,0 +1,51 @@
+<!doctype html><html><head><meta charset="UTF-8"><link rel='stylesheet' href='../shared/styles.css' /><script src="../shared/script.js"></script></head><body class="header">
+
+<style type="text/css">
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+.thing {
+  position: absolute;
+  width: 10vmin;
+  height: 10vmin;
+  border-radius: 50%;
+  background: rgb(187, 204, 170);
+}
+
+</style>
+
+<script src="https://code.jquery.com/jquery-1.10.2.js"></script>
+
+<script>
+var viewportW = document.body.offsetWidth;
+var viewportH = document.body.offsetHeight;
+
+// Creating a bunch of elements.
+for (var i = 0; i < (Math.random() * 100) + 50; i ++) {
+  var el = document.createElement("div");
+  el.classList.add("thing");
+  document.body.appendChild(el);
+
+  // Position randomly.
+  el.style.left = (Math.random() * viewportW) + "px";
+  el.style.top = (Math.random() * viewportH) + "px";
+
+  // Move randomly.
+  var deltaX = (Math.round(Math.random()) ? 1 : -1) * Math.random() * 200;
+  var deltaY = (Math.round(Math.random()) ? 1 : -1) * Math.random() * 200;
+
+  $(el).animate({
+    left: "+=" + deltaX + "vmin",
+    top: "+=" + deltaY + "vmin",
+  }, {
+    duration: 5000
+  });
+}
+</script>
+
+</body></html>


### PR DESCRIPTION
I wanted to get a feel for how much you improved the markup-view performance with the recent changes you made, so I created this page that uses jquery to animate many nodes by mutating their style attributes really fast.
And I thought we might want to keep this page here in this repo, to test again later.

Testing this page on FF38 really shows the performance problem: the animations are really really janky.
Testing on FF40 (with your changes) without e10s: it's a lot better. It's still a bit janky (especially at the beginning), but it's ok.
Testing on FF40, with e10s: it's perfect, I can't perceive any difference with or without the inspector open.

So, great work!
As discussed sometime in the past, I only see one more thing we could do if this kind of problem comes back on more complex pages: using a client-side setInterval loop that batches DOM updates to the markup-view.