### PR TITLE
Font loading example

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@ var a = 1;
 
 <h2>Inspector</h2>
 <ul>
+  <li><a href="inspector/font-loading.html">Fonts loaded, both broken and properly</a></li>
   <li><a href="inspector/mutations.html">Markup mutations</a></li>
   <li><a href="inspector/svg.html">SVG in HTML</a></li>
   <li><a href="inspector/attributes.html">Variety of attributes for markup views</a></li>

--- a/inspector/font-loading.html
+++ b/inspector/font-loading.html
@@ -1,0 +1,27 @@
+<!doctype html><html><head><meta charset="UTF-8"><link rel='stylesheet' href='../shared/styles.css' /><script src="../shared/script.js"></script></head><body class="header">
+
+<h1>Font Loading</h1>
+
+<style type="text/css">
+@import url(https://fonts.googleapis.com/css?family=Oswald);
+
+.load-badly {
+  /* purposefully mispelled to force fallback */
+  font-family: 'Osswald', sans-serif;
+}
+
+.load-well {
+  font-family: 'Oswald', sans-serif;
+}
+
+</style>
+
+<p>
+  <pre style="display: inline">@font-face</pre> improperly loading a font file and properly loading a file for testing font fallback functionality in the Font panel.
+</p>
+
+<p class="load-badly">This paragraph should be in Oswald, but instead is using the system sans-serif.</p>
+
+<p class="load-well">This paragraph is in Oswald, instead of the sans-serif.</p>
+
+</body></html>


### PR DESCRIPTION
Doesn't load a font based on a misspelling to test fallbacks.
